### PR TITLE
Enable edge-to-edge

### DIFF
--- a/app/src/main/kotlin/com/richardluo/globalIconPack/ui/IconPackMergerActivity.kt
+++ b/app/src/main/kotlin/com/richardluo/globalIconPack/ui/IconPackMergerActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.PredictiveBackHandler
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.animation.AnimatedContent
@@ -133,6 +134,7 @@ class IconPackMergerActivity : ComponentActivity() {
   private val avm: MergerActivityVM by viewModels()
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    enableEdgeToEdge()
     super.onCreate(savedInstanceState)
     setContent {
       SampleTheme {

--- a/app/src/main/kotlin/com/richardluo/globalIconPack/ui/IconVariantActivity.kt
+++ b/app/src/main/kotlin/com/richardluo/globalIconPack/ui/IconVariantActivity.kt
@@ -3,6 +3,7 @@ package com.richardluo.globalIconPack.ui
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Box
@@ -72,6 +73,7 @@ class IconVariantActivity : ComponentActivity() {
   private val avm: IconVariantAVM by viewModels()
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    enableEdgeToEdge()
     super.onCreate(savedInstanceState)
 
     runCatching { vm.iconPack }

--- a/app/src/main/kotlin/com/richardluo/globalIconPack/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/richardluo/globalIconPack/ui/MainActivity.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.clickable
@@ -90,6 +91,7 @@ class MainActivity : ComponentActivity() {
   private val vm: MainVM by viewModels()
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    enableEdgeToEdge()
     super.onCreate(savedInstanceState)
 
     // If onNewIntent() is not getting called


### PR DESCRIPTION
Enable edge-to-edge to hide ugly backgrounds on status bar and navigation bar.
| Before | After |
|:-:|:-:|
|<img width="1440" height="3040" alt="Screenshot_20250717-173842" src="https://github.com/user-attachments/assets/c5a9cd72-9008-47d0-893f-3818b3fe6c6c" /> | <img width="1440" height="3040" alt="Screenshot_20250717-181620" src="https://github.com/user-attachments/assets/9bca555b-334c-45a6-90dc-988354e12502" /> 