### PR TITLE
fix: hookGetState ClassCastException on Pixel Launcher CANARY

### DIFF
--- a/app/src/main/kotlin/com/richardluo/globalIconPack/xposed/CalendarAndClockHook.kt
+++ b/app/src/main/kotlin/com/richardluo/globalIconPack/xposed/CalendarAndClockHook.kt
@@ -249,16 +249,23 @@ class CalendarAndClockHook(private val clockUseFallbackMask: Boolean) : Hook {
     tryHook("hookGetState") {
         tryDo {
           // https://cs.android.com/android/platform/superproject/+/android-15.0.0_r20:frameworks/libs/systemui/iconloaderlib/src/com/android/launcher3/icons/IconProvider.java;l=97
+          // getStateForApp may return String (old) or PersistedItemState (new >= Android 16)
+          // In the PersistedItemState case, the original method already handles calendar state
+          // internally via withAdditionalValues, so we only modify the String case.
           iconProvider
             .allMethods("getStateForApp", ApplicationInfo::class.java)
             .hook {
-              replace {
-                val info = args[0].asType<ApplicationInfo>() ?: return@replace callOriginalMethod()
-                return@replace if (calendars.contains(info.packageName))
-                  (callOriginalMethod<String>() +
+              after {
+                val info = args[0].asType<ApplicationInfo>() ?: return@after
+                val originalResult = result ?: return@after
+                // If the method already returns a non-String (e.g. PersistedItemState),
+                // the original implementation already handles calendar state — skip.
+                if (originalResult !is String) return@after
+                if (calendars.contains(info.packageName)) {
+                  result = originalResult +
                     " " +
-                    (Calendar.getInstance().get(Calendar.DAY_OF_MONTH) - 1))
-                else callOriginalMethod()
+                    (Calendar.getInstance().get(Calendar.DAY_OF_MONTH) - 1)
+                }
               }
             }
             .registerToScopeOrFail()

--- a/app/src/main/kotlin/com/richardluo/globalIconPack/xposed/CalendarAndClockHook.kt
+++ b/app/src/main/kotlin/com/richardluo/globalIconPack/xposed/CalendarAndClockHook.kt
@@ -250,21 +250,24 @@ class CalendarAndClockHook(private val clockUseFallbackMask: Boolean) : Hook {
         tryDo {
           // https://cs.android.com/android/platform/superproject/+/android-15.0.0_r20:frameworks/libs/systemui/iconloaderlib/src/com/android/launcher3/icons/IconProvider.java;l=97
           // getStateForApp may return String (old) or PersistedItemState (new >= Android 16)
-          // In the PersistedItemState case, the original method already handles calendar state
-          // internally via withAdditionalValues, so we only modify the String case.
+          // The original only adds day-of-month for mCalendar.getPackageName() (hardcoded
+          // com.google.android.calendar). For icon-pack calendar icons mapped to other
+          // packages, we must append the day offset ourselves.
           iconProvider
             .allMethods("getStateForApp", ApplicationInfo::class.java)
             .hook {
               after {
                 val info = args[0].asType<ApplicationInfo>() ?: return@after
+                if (!calendars.contains(info.packageName)) return@after
+                val dayOffset = Calendar.getInstance().get(Calendar.DAY_OF_MONTH) - 1
                 val originalResult = result ?: return@after
-                // If the method already returns a non-String (e.g. PersistedItemState),
-                // the original implementation already handles calendar state — skip.
-                if (originalResult !is String) return@after
-                if (calendars.contains(info.packageName)) {
-                  result = originalResult +
-                    " " +
-                    (Calendar.getInstance().get(Calendar.DAY_OF_MONTH) - 1)
+                result = when (originalResult) {
+                  is String -> "$originalResult $dayOffset"
+                  // PersistedItemState: call withAdditionalValues to append the day
+                  else -> originalResult.javaClass.method(
+                    "withAdditionalValues",
+                    Array<String>::class.java
+                  )?.invoke(originalResult, arrayOf(dayOffset.toString())) ?: originalResult
                 }
               }
             }


### PR DESCRIPTION
getStateForApp now returns PersistedItemState (not String) on newer Pixel Launcher builds. The original method already handles calendar state internally via withAdditionalValues, so we skip modification for non-String return types.

- Change hook from replace+callOriginalMethod<String> to after hook
- Check return type: modify only if result is String
- Skip if result is PersistedItemState (already handled)

Fixes ClassCastException on Pixel Launcher CANARY where getStateForApp returns PersistedItemState instead of String.