### PR TITLE
fix: do not crash when getInstalledApplications is denied

### DIFF
--- a/app/src/main/kotlin/com/richardluo/globalIconPack/ui/repo/Apps.kt
+++ b/app/src/main/kotlin/com/richardluo/globalIconPack/ui/repo/Apps.kt
@@ -4,6 +4,7 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import com.richardluo.globalIconPack.ui.MyApplication
 import com.richardluo.globalIconPack.ui.model.AppCompInfo
+import com.richardluo.globalIconPack.utils.Logger
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -23,13 +24,25 @@ object Apps {
         val userApps = mutableListOf<AppCompInfo>()
         val systemApps = mutableListOf<AppCompInfo>()
 
-        app.packageManager
-          .getInstalledApplications(PackageManager.MATCH_UNINSTALLED_PACKAGES)
-          .forEach { info ->
-            if ((info.flags and ApplicationInfo.FLAG_SYSTEM) == ApplicationInfo.FLAG_SYSTEM)
-              systemApps.add(AppCompInfo(app, info))
-            else userApps.add(AppCompInfo(app, info))
+        val pm = app.packageManager
+        // MATCH_ANY_USER is added to this query inside system server by
+        // BypassCrossUserPermission, so when that bypass stops working the call throws
+        // SecurityException and takes the whole process down from this flow. Retrying without
+        // MATCH_UNINSTALLED_PACKAGES would fail the same way, since the flag is not added here,
+        // so just degrade to an empty list.
+        val installed: List<ApplicationInfo> =
+          try {
+            pm.getInstalledApplications(PackageManager.MATCH_UNINSTALLED_PACKAGES)
+          } catch (e: Exception) {
+            Logger.logE(e)
+            emptyList()
           }
+
+        installed.forEach { info ->
+          if ((info.flags and ApplicationInfo.FLAG_SYSTEM) == ApplicationInfo.FLAG_SYSTEM)
+            systemApps.add(AppCompInfo(app, info))
+          else userApps.add(AppCompInfo(app, info))
+        }
 
         arrayOf(
           userApps.distinct().sortedBy { it.label },

--- a/app/src/main/kotlin/com/richardluo/globalIconPack/xposed/BypassCrossUserPermission.kt
+++ b/app/src/main/kotlin/com/richardluo/globalIconPack/xposed/BypassCrossUserPermission.kt
@@ -30,10 +30,17 @@ object BypassCrossUserPermission {
       }
     }
 
-    computerEngineC.allMethods("enforceCrossUserPermission").hookCompat {
-      before {
-        val callingUid = args.getOrNull(0).asType<Int>() ?: return@before
-        if (gipUid == callingUid) result = null
+    // API 37 inserted a leading int, so callingUid moved from the first to the second parameter.
+    // Both releases end the leading run of ints with userId and put callingUid right before it,
+    // so derive the index from the signature instead of assuming a position.
+    computerEngineC.allMethods("enforceCrossUserPermission").forEach { m ->
+      val uidIndex = m.parameterTypes.takeWhile { it == Int::class.javaPrimitiveType }.size - 2
+      if (uidIndex < 0) return@forEach
+      m.hookCompat {
+        before {
+          val callingUid = args.getOrNull(uidIndex).asType<Int>() ?: return@before
+          if (gipUid == callingUid) result = null
+        }
       }
     }
 


### PR DESCRIPTION
## Problem

Any app list killed the process:

java.lang.SecurityException: MATCH_ANY_USER flag requires INTERACT_ACROSS_USERS permission
  at ApplicationPackageManager.getInstalledApplications
  at Apps$special$$inlined$map$1$2.emit

## Cause

`BypassCrossUserPermission` adds `MATCH_ANY_USER`, then excuses the check by hooking
`enforceCrossUserPermission`. On `sdk_full 37.2` that method has an extra leading `int`, so
`callingUid` is at argument 1, not 0:

published AOSP   enforceCrossUserPermission(int callingUid, int userId, ...)
sdk_full 37.2    enforceCrossUserPermission(int, int callingUid, int userId, ...)

The hook kept reading argument 0, never matched `gipUid`, and stopped excusing the check.
`getInstalledApplications` is unchanged, so the flag was still added but no longer bypassed.

Not visible in AOSP — `main` and `android-17.0.0_r1` both still have the old signature. Taken
from a disassembly of the device's `services.jar`.

## Fix

Derive the index from the signature: `callingUid` is always the last-but-one of the leading
ints. Gives 0 on AOSP shapes, 1 on 37.2. An `SDK_INT >= 37` check would break
`android-17.0.0_r1`, which is API 37 with the old signature.

Second commit catches the exception in `Apps.flow` so this class of failure degrades to an empty
list instead of killing the

## Testing

Pixel 10 Pro (37.2): app liso crashes across a reboot.
Nothing Phone 3a (API 36): crivation gives index 0 —unchanged.
