### PR TITLE
fix: do not build a bitmap for empty drawable bounds

### DIFF
--- a/app/src/main/kotlin/com/richardluo/globalIconPack/utils/BitmapCache.kt
+++ b/app/src/main/kotlin/com/richardluo/globalIconPack/utils/BitmapCache.kt
@@ -8,8 +8,9 @@ import androidx.core.graphics.createBitmap
 class BitmapCache {
   private var bitmap: Bitmap? = null
 
-  fun getBitmap(bounds: Rect, draw: Canvas.() -> Unit) =
-    if (
+  fun getBitmap(bounds: Rect, draw: Canvas.() -> Unit): Bitmap? =
+    if (bounds.isEmpty) null
+    else if (
       bitmap == null ||
         bitmap!!.getWidth() != bounds.width() ||
         bitmap!!.getHeight() != bounds.height()

--- a/app/src/main/kotlin/com/richardluo/globalIconPack/utils/IconHelper.kt
+++ b/app/src/main/kotlin/com/richardluo/globalIconPack/utils/IconHelper.kt
@@ -41,7 +41,7 @@ object IconHelper {
             if (mask != null) super.draw(this) else super.drawClip(this)
           }
         }
-        .let { canvas.drawBitmap(it, null, bounds, paint) }
+        ?.let { canvas.drawBitmap(it, null, bounds, paint) }
     }
 
     override fun setAlpha(alpha: Int) {
@@ -101,7 +101,7 @@ object IconHelper {
     override fun draw(canvas: Canvas) {
       cache
         .getBitmap(bounds) { drawIcon(paint, bounds, back, upon, mask) { super.draw(this) } }
-        .let { canvas.drawBitmap(it, null, bounds, paint) }
+        ?.let { canvas.drawBitmap(it, null, bounds, paint) }
     }
 
     override fun setAlpha(alpha: Int) {

--- a/app/src/main/kotlin/com/richardluo/globalIconPack/utils/MonochromeDrawable.kt
+++ b/app/src/main/kotlin/com/richardluo/globalIconPack/utils/MonochromeDrawable.kt
@@ -27,11 +27,9 @@ private class MonoForegroundDrawable(private val mono: Drawable, @ColorInt color
   private val monoBitmapCache = BitmapCache()
 
   override fun draw(canvas: Canvas) {
-    val monoBitmap =
-      monoBitmapCache.getBitmap(bounds) {
-        mono.draw(this)
-      }
-    canvas.drawBitmap(monoBitmap, null, bounds, paint)
+    monoBitmapCache
+      .getBitmap(bounds) { mono.draw(this) }
+      ?.let { canvas.drawBitmap(it, null, bounds, paint) }
   }
 
   override fun setAlpha(alpha: Int) {


### PR DESCRIPTION
## Problem

The launcher's icon loader thread died while generating an icon, which stops **every** icon from loading, not just the offending one:

```
FATAL EXCEPTION: launcher-loader
Process: com.google.android.apps.nexuslauncher
java.lang.IllegalArgumentException: width and height must be > 0
    at BitmapCache.getBitmap(BitmapCache.kt:32)
    at IconHelper$CustomDrawable.draw(IconHelper.kt:103)
    ... CustomDrawable -> UnClipAdaptiveIconDrawable -> CustomDrawable x7 ...
    at BaseIconFactory.createBitmap -> createBadgedIconBitmap   (module hook)
    at IconCache.getShortcutIcon
```

## Cause

`BitmapCache.getBitmap()` passes the drawable bounds straight to `createBitmap()`, so empty bounds throw. Since the icon is drawn inside the `createBadgedIconBitmap()` hook, the exception escapes into the launcher instead of staying contained.

Bounds can reach zero because each wrapper layer insets by `ceil(size * insetFraction)`. That ratchets down fast at small render sizes — `100 -> 72 -> 52 -> 38 -> 26 -> 18 -> 12 -> 8 -> 4 -> 2 -> 0` — so a deeply nested icon runs out of pixels.

## Fix

Return `null` for empty bounds and skip the draw, which is how framework drawables behave. `drawIcon()` already tried to guard this but tested `< 0` rather than `<= 0`, so zero slipped through.

All three `BitmapCache` call sites now share the same `?.let { canvas.drawBitmap(...) }` shape.

## Scope

This stops the crash; it does not address *why* an icon ends up ~7 wrapper layers deep. That nesting suggests icon processing being applied to an already-processed icon, which is worth investigating separately. With this change the innermost layers render nothing instead of taking the launcher down.

## Testing

Pixel 10 Pro, Android 17 (API 37), Vector/LSPosed. Built, installed and run: icons load normally and the launcher is stable.

To be precise about the limits of that: the original crash came from a log of a rare path (a fallback shortcut icon nested deep enough to run out of pixels) and I did not manage to reproduce it on demand, so this is absence of regression rather than a direct before/after of the guard firing. The stack trace above identifies the throw site unambiguously, and returning null for empty bounds is what framework drawables already do.
