### PR TITLE
fix: replace icons on API 37 via getDrawableInternal

### DIFF
--- a/app/src/main/kotlin/com/richardluo/globalIconPack/xposed/ReplaceIcon.kt
+++ b/app/src/main/kotlin/com/richardluo/globalIconPack/xposed/ReplaceIcon.kt
@@ -118,36 +118,58 @@ class ReplaceIcon(
 
   context(xposed: XposedInterface)
   override fun onHookApp(param: XposedModuleInterface.PackageReadyParam) {
-    // Find the drawable corresponding to the replaced icon
-    getDrawableForDensityM?.hookCompat {
+    // Find the drawable corresponding to the replaced icon.
+    // The indexes point at the icon resource id and the density in the hooked method arguments,
+    // densityIndex is null when the method takes no density.
+    fun HookBuilder.replaceMarkedIconHook(resIdIndex: Int, densityIndex: Int?) {
       before {
-        val resId = args[0] as? Int ?: return@before
-        val density = args[1] as? Int ?: return@before
-        if (resId == android.R.drawable.sym_def_app_icon) {
-          result = proceed<Drawable?>()?.let { getSC()?.genIconFrom(it) ?: it }
-          return@before
-        }
-        result =
-          when (resId.highByte()) {
-            IN_SC -> getSC()?.getIcon(resId.withHighByte(SC_DEFAULT), density)
-            NOT_IN_SC -> {
-              args[0] = resId.withHighByte(ANDROID_DEFAULT)
-              var drawable = proceedWithArgs<Drawable?>()
-
-              if (
-                forceMonochrome &&
-                  Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-                  drawable is AdaptiveIconDrawable
-              )
-                drawable.monochrome?.let {
-                  drawable = MonochromeDrawable(thisObject.asType()!!, it)
-                }
-
-              drawable?.let { getSC()?.genIconFrom(it) ?: it }
-            }
-            else -> return@before
+        // Both hooked methods can sit in the same call chain, so proceeding from the outer one
+        // runs the inner one. Let only the outermost generate an icon, otherwise the fallback
+        // back, upon and mask would be applied twice.
+        if (replacingIcon.get() == true) return@before
+        val resId = args[resIdIndex] as? Int ?: return@before
+        replacingIcon.set(true)
+        try {
+          if (resId == android.R.drawable.sym_def_app_icon) {
+            result = proceed<Drawable?>()?.let { getSC()?.genIconFrom(it) ?: it }
+            return@before
           }
+          result =
+            when (resId.highByte()) {
+              IN_SC -> {
+                val density = densityIndex?.let { args[it] as? Int } ?: 0
+                getSC()?.getIcon(resId.withHighByte(SC_DEFAULT), density)
+              }
+              NOT_IN_SC -> {
+                args[resIdIndex] = resId.withHighByte(ANDROID_DEFAULT)
+                var drawable = proceedWithArgs<Drawable?>()
+
+                if (
+                  forceMonochrome &&
+                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                    drawable is AdaptiveIconDrawable
+                )
+                  drawable.monochrome?.let {
+                    drawable = MonochromeDrawable(thisObject.asType()!!, it)
+                  }
+
+                drawable?.let { getSC()?.genIconFrom(it) ?: it }
+              }
+              else -> return@before
+            }
+        } finally {
+          replacingIcon.set(false)
+        }
       }
+    }
+
+    getDrawableForDensityM?.hookCompat { replaceMarkedIconHook(0, 1) }
+
+    // Since API 37 ApplicationPackageManager resolves item icons through getDrawableInternal()
+    // instead of Resources.getDrawableForDensity(), so the marked res id never reaches the hook
+    // above and every icon outside the launcher falls back to sym_def_app_icon.
+    classOf("android.app.ApplicationPackageManager")?.allMethods("getDrawableInternal")?.hookCompat {
+      replaceMarkedIconHook(1, null)
     }
 
     // ArchivedAppIcon
@@ -331,6 +353,9 @@ private fun replaceIconInItemInfo(info: PackageItemInfo, id: Int?, sc: Source) {
 private typealias BatchReplacer = (seq: Sequence<Any?>, sc: Source) -> Unit
 
 private val blockReplaceIconResId = ThreadLocal.withInitial { false }
+
+// Keeps the drawable hooks from nesting, see replaceMarkedIconHook()
+private val replacingIcon = ThreadLocal.withInitial { false }
 
 private inline fun runBlockReplaceIconResId(crossinline block: () -> Unit) {
   if (blockReplaceIconResId.get() == true) return


### PR DESCRIPTION
## Problem

On Android 17 (API 37) icons are replaced correctly in the launcher, but **every other surface** — system ui notifications, Settings > All apps, the share sheet, recents — falls back to the generic Android icon.

## Cause

The icon res id in `PackageItemInfo` is marked with a fake package byte (`0x6f` in-pack / `0x6e` not-in-pack) and decoded again by hooking `Resources.getDrawableForDensity()`.

Since API 37, `ApplicationPackageManager` resolves item icons through a new `getDrawableInternal(String, int, ApplicationInfo, boolean)` plus its own private `getDrawableForDensity(int, int)`, rather than `Resources.getDrawableForDensity()`. The marked id therefore never reaches the hook and fails to resolve. The framework says so directly:

```
E/...: No package ID 6e found for resource ID 0x6e0f0000
W/PackageManager: Failure retrieving resources for com.google.android.apps.scone: Resource ID #0x6e0f0000
E/...: Invalid resource ID 0x6f00000e
```

`PackageManager` swallows the `NotFoundException` and falls back to `loadDefaultIcon()`, which is why every app ends up as `sym_def_app_icon`. The module then themes *that*, producing a screen of identical placeholder icons.

Instrumenting the hooks confirmed it: marked res ids reaching `Resources.getDrawableForDensity` (either overload) — **0**; calls to `ApplicationPackageManager.getDrawable` — **0**.

The launcher is unaffected because it loads icons through `IconCache`/`LauncherApps` and never calls `ApplicationInfo.loadIcon()`.

## Fix

Extract the decoding into `replaceMarkedIconHook()`, parameterised by the argument positions of the res id and the density, and install it on `getDrawableInternal()` as well as the existing `Resources.getDrawableForDensity()`.

Both parameters are argument indices, so each call site reads off the corresponding signature:

- `replaceMarkedIconHook(0, 1)` for `getDrawableForDensity(resId, density, theme)`
- `replaceMarkedIconHook(1, null)` for `getDrawableInternal(pkg, resId, appInfo, bool)` — no density argument

No API level check is needed: `classOf()` / `allMethods()` return nothing on releases without the method, so the extra hook simply doesn't install there.

## Testing

Pixel 10 Pro, Android 17 (API 37), Vector/LSPosed. Settings > All apps and the notification shade both render correctly themed icons; framework icon-resource failures went from dozens per screen to **0**. Launcher icons unchanged.

## Re-entrancy

Both hooked methods can appear in the same call chain, since proceeding from `getDrawableInternal()` can reach `Resources.getDrawableForDensity()`. For a marked res id that is harmless — the id is restored before proceeding, so the inner hook sees a plain `0x7f...` and ignores it. For `sym_def_app_icon` it is not: both hooks match it, and the fallback back/upon/mask would be composited twice.

A thread-local guard lets only the outermost invocation generate an icon, matching the existing `blockReplaceIconResId` pattern in this file. It is cleared in a `finally`, so a throwing drawable load cannot leave it stuck.


## Cross-version check

Reflecting on `ApplicationPackageManager` on a second device running **Android 16 (API 36)** — Nothing Phone (3a) — against the API 37 device:

```
API 36:  public  getDrawable(String, int, ApplicationInfo)
         private getDrawableForLauncher(String, int, ApplicationInfo)
         private getDrawableForDensity(int, int)

API 37:  public  getDrawableInternal(String, int, ApplicationInfo, boolean)
         public  getDrawable(String, int, ApplicationInfo)
         private getDrawableForDensity(int, int)
```

Three things follow:

- `getDrawableInternal()` genuinely is new in API 37 — it is absent on 36, so the added hook is a real no-op there rather than merely assumed to be. `allMethods()` returns nothing and logs a line, which is the same graceful path other hooks in this file already take when a class or method is missing on a given release.
- API 37 looks to have merged `getDrawable()` and `getDrawableForLauncher()` into one method, with the trailing `boolean` standing in for the launcher variant.
- The resource id sits at argument index **1** in all three signatures, which is what this hook assumes.
