### PR TITLE
fix: probe for a valid SELinux type when sharing the database

### DIFF
--- a/app/src/main/kotlin/com/richardluo/globalIconPack/ui/viewModel/MainVM.kt
+++ b/app/src/main/kotlin/com/richardluo/globalIconPack/ui/viewModel/MainVM.kt
@@ -145,18 +145,26 @@ class MainVM(context: Application) : ContextVM(context), ILoadable by Loadable()
     if (!db.isShareDB()) return
     val dbFile = File(db)
     val parent = dbFile.parent!!
-    if (dbFile.exists() && isAllFilesUsable(parent)) return
+    // Not guarded by isAllFilesUsable(): the db is read by the hooked system processes, and this
+    // app can always read it regardless of whether they can, so its own access proves nothing.
 
     Shell.cmd(
         "set -e",
         "if ! [ -f $db ]; then touch $db; fi",
-        "context=\"u:object_r:lsposed_file:s0\"",
-        $$"chown 9999:9999 $$parent && chmod 0777 $$parent && chcon $context $$parent",
-        $$"for file in $$parent/*; do chown 9999:9999 $file && chmod 0666 $file && chcon $context $file; done",
+        // chcon accepts a type the running policy does not define and writes it anyway, leaving
+        // an unresolvable label that denies every domain. Frameworks also disagree on the name,
+        // so use the first type this policy actually knows rather than hardcoding one. The
+        // previously hardcoded type is tried first so setups it already works on are untouched.
+        $$"context=",
+        $$"for t in lsposed_file magisk_file xposed_data; do if echo -n \"u:object_r:$t:s0\" > /sys/fs/selinux/context 2>/dev/null; then context=\"u:object_r:$t:s0\"; break; fi; done",
+        $$"chown 9999:9999 $$parent && chmod 0777 $$parent",
+        $$"if [ -n \"$context\" ]; then chcon \"$context\" $$parent; fi",
+        $$"for file in $$parent/*; do chown 9999:9999 $file && chmod 0666 $file; if [ -n \"$context\" ]; then chcon \"$context\" $file; fi; done",
       )
       .exec()
       .throwOnFail("Database permission setting failed")
-    // Check again
+    // Check again. This only proves the db is not broken for this app, the hooked processes rely
+    // on the SELinux type above.
     if (!dbFile.exists() || !isAllFilesUsable(parent))
       throw Exception("Unable to read and write after resetting permission!")
   }


### PR DESCRIPTION
## Problem

`MainVM.resetDBPermission()` hardcodes the SELinux type applied to the shared database:

```kotlin
"context=\"u:object_r:lsposed_file:s0\"",
```

Not every Xposed framework defines that type — Vector's policy has no `lsposed_file`. `chcon` accepts an unknown type and writes it anyway, leaving the database with a label the policy cannot resolve, which denies **every** domain instead of just failing. The hooked processes then cannot open it:

```
SQLiteCantOpenDatabaseException: unable to open database file
  (code 14 SQLITE_CANTOPEN): Permission denied
```

Probing `/sys/fs/selinux/context` on an affected device:

```
xposed_data  -> valid
lsposed_file -> invalid
magisk_file  -> invalid
```

## The guard hid it

```kotlin
if (dbFile.exists() && isAllFilesUsable(parent)) return
```

The database is read directly by the hooked system processes, but `isAllFilesUsable()` tests whether **this app** can read it — and this app always can, whatever the label. So the guard passed on exactly the setups that were broken, the repair never ran, and a wrong label could persist indefinitely without the app ever noticing. That is why this was only ever fixable with an external Magisk module.

## Fix

- The previously hardcoded type is probed **first**, so any setup it already works on keeps exactly the label it has today and is untouched by this change. Only setups where it is invalid fall through.

Probe the candidate types and use the first the running policy knows, rather than hardcoding one. Ownership and mode are applied even when none matches, so an unrecognised policy degrades instead of failing outright.
- Drop the `isAllFilesUsable()` early return. Both callers are on setup or mode change, so always applying costs one root shell there, not one per launch. The same check is kept afterwards, now only as a sanity check — with a comment noting it says nothing about the hooked processes.

## Testing

Pixel 10 Pro, Android 17 (API 37), Vector.

Built into an APK and installed, then the database was deliberately put into the exact broken state this fixes and the app was launched so `resetDBPermission()` ran through its real code path:

```
before:  u:object_r:lsposed_file:s0    root:root      0600   (seeded)
after:   u:object_r:xposed_data:s0     nobody:nobody  0666   (repaired)
```

No exception, no crash, and re-running is a no-op on an already-correct database.

Two assumptions behind the change were checked rather than assumed:

- the emitted shell was read back out of the built dex, confirming the multi-dollar strings keep `$t` and `$context` literal while interpolating the path
- `context=` does survive across separate `Shell.cmd()` argument lines, verified in a real `su` session

Note the old code could not have repaired the seeded state at all: `isAllFilesUsable()` returns true for this app regardless of the label, so the early return fired and the shell never ran.

> Companion to the `GIP_FIX.zip` change, which had the same hardcoded type. With this fixed the module becomes a fallback rather than a requirement.



